### PR TITLE
Removed redundant call to SetIgorOption that is missing in IGOR 8

### DIFF
--- a/NCNR_User_Procedures/Reduction/SANS/QKK_DesmearingUtils.ipf
+++ b/NCNR_User_Procedures/Reduction/SANS/QKK_DesmearingUtils.ipf
@@ -26,7 +26,7 @@ Proc Init_MainUSANS()
 		String/G root:Packages:NIST:gAngstStr = num2char(-59)
 //		Variable/G root:myGlobals:gIsMac = 0
 		//SetIgorOption to keep some PC's (graphics cards?) from smoothing the 2D image
-		Execute "SetIgorOption WinDraw,forceCOLORONCOLOR=1"
+		//Execute "SetIgorOption WinDraw,forceCOLORONCOLOR=1"
 	endif
 	
 	String/G root:Packages:NIST:USANS:Globals:gUSANSFolder  = "root:Packages:NIST:USANS"

--- a/NCNR_User_Procedures/Reduction/SANS/QKK_Initialize.ipf
+++ b/NCNR_User_Procedures/Reduction/SANS/QKK_Initialize.ipf
@@ -119,7 +119,7 @@ Function InitGlobals()
 		String/G root:Packages:NIST:gAngstStr = num2char(-59)
 		Variable/G root:myGlobals:gIsMac = 0
 		//SetIgorOption to keep some PC's (graphics cards?) from smoothing the 2D image
-		Execute "SetIgorOption WinDraw,forceCOLORONCOLOR=1"
+		//Execute "SetIgorOption WinDraw,forceCOLORONCOLOR=1"
 	endif
 	
 	//global to set log scale as the default for display of RAW data


### PR DESCRIPTION
This was a single commit added to the svn repository by @geishm-ansto that was never incorporated, so far as I can tell.

This should be a good test of the PR system for @srkline-igor.