### PR TITLE
Reinstate Qdev generation for SANS and VSANS data

### DIFF
--- a/NCNR_User_Procedures/Reduction/SANS/Write_SANS_NXcanSAS.ipf
+++ b/NCNR_User_Procedures/Reduction/SANS/Write_SANS_NXcanSAS.ipf
@@ -279,13 +279,10 @@ Function WriteNxCanSAS2D(type,fullpath,dialog)
 	Make/O/T/N=2 $(dataBase + ":i:attrVals") = {"1/cm","Idev"}
 	CreateVarNxCansas(fileID,dataParent,"sasdata","I",data,$(dataBase + ":i:attr"),$(dataBase + ":i:attrVals"))
 
-    //
-    // TODO: Reinstate Qdev/resolutions when I can fix the reader issue
-    //
 	// Create qx and qy entry
 	NewDataFolder/O/S $(dataBase + ":q")
-	Make/O/T/N=2 $(dataBase + ":q:attr") = {"units"}//,"resolutions"}
-	Make/O/T/N=2 $(dataBase + ":q:attrVals") = {"1/angstrom"}//,"Qdev"}
+	Make/O/T/N=2 $(dataBase + ":q:attr") = {"units","resolutions"}
+	Make/O/T/N=2 $(dataBase + ":q:attrVals") = {"1/angstrom","Qdev"}
 	CreateVarNxCansas(fileID,dataParent,"sasdata","Q",qxy_vals,$(dataBase + ":q:attr"),$(dataBase + ":q:attrVals"))
 	
 	// Create idev entry

--- a/NCNR_User_Procedures/Reduction/VSANS/V_Write_VSANS_NXcanSAS.ipf
+++ b/NCNR_User_Procedures/Reduction/VSANS/V_Write_VSANS_NXcanSAS.ipf
@@ -349,13 +349,11 @@ v_toc()
 		Make/O/T/N=2 $(dataBase + ":i:attr") = {"units","uncertainties"}
 		Make/O/T/N=2 $(dataBase + ":i:attrVals") = {"1/cm","Idev"}
 		CreateVarNxCansas(fileID,dataParent,"sasdata","I",data,$(dataBase + ":i:attr"),$(dataBase + ":i:attrVals"))
-		//
-		// TODO: Reinstate Qdev/resolutions when I can fix the reader issue
-		//
+
 		// Create qx and qy entry
 		NewDataFolder/O/S $(dataBase + ":q")
-		Make/O/T/N=2 $(dataBase + ":q:attr") = {"units"}//,"resolutions"}
-		Make/O/T/N=2 $(dataBase + ":q:attrVals") = {"1/angstrom"}//,"Qdev"}
+		Make/O/T/N=2 $(dataBase + ":q:attr") = {"units","resolutions"}
+		Make/O/T/N=2 $(dataBase + ":q:attrVals") = {"1/angstrom","Qdev"}
 		CreateVarNxCansas(fileID,dataParent,"sasdata","Q",qxy_vals,$(dataBase + ":q:attr"),$(dataBase + ":q:attrVals"))
 		// Create idev entry
 		CreateVarNxCansas(fileID,dataParent,"sasdata","Idev",data_err,units,inv_cm)


### PR DESCRIPTION
The issue related to SasView loading dX data has been resolved so we should restore this.